### PR TITLE
Bound the commonmark version to be less then v0.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
 
   run:
     - python
-    - commonmark >=0.5.6
+    - commonmark >=0.5.6,<0.8.1
     - sphinx
 
 test:


### PR DESCRIPTION


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This branch provides an upper bound to the commonmark dependency of the module. CommonMark introduced the pep8 compliant module name of commonmark in version 0.8.0 and removed the non-compliant CommonMark module name in 0.8.1. Since this later version has now landed in conda-forge, this package needs to make sure it installs the older versions of commonmark. This PR closes #12.

<!--
Please add any other relevant info below:
-->
